### PR TITLE
Enable X-Forwarded-For HTTP header log

### DIFF
--- a/scripts/install_magento.sh
+++ b/scripts/install_magento.sh
@@ -111,6 +111,10 @@ events {
 }
 
 http {
+
+real_ip_header X-Forwarded-For;
+set_real_ip_from 0.0.0.0/0;
+
 upstream fastcgi_backend {
         server unix:/tmp/php-cgi.socket;
         server 127.0.0.1:9000 backup;


### PR DESCRIPTION
This PR enables nginx to log the original client IP connected to the ELB, using the `X-Forwarded-For` HTTP header. Since AWS can't guarantee the ELB IP (best practices to use the DNS name), the source is `0.0.0.0/0`, although the web servers are not on a public network. 