### PR TITLE
Change the Auto Scaling Group HealthCheckType

### DIFF
--- a/templates/webserver.template
+++ b/templates/webserver.template
@@ -457,6 +457,7 @@
                         "autoscaling:EC2_INSTANCE_TERMINATE_ERROR"
                     ]
                 },
+                "HealthCheckType": "ELB",
                 "Tags": [
                     {
                         "Key": "Name",


### PR DESCRIPTION
This PR changes the `HealthCheckType` from EC2 to ELB. 
We verified the web server is not able to receive requests (50x in the ELB) however the EC2 instance is not replaced (the check type is `EC2` rather than `ELB`), resulting in an unhealthy instance in the ELB.