### PR TITLE
Update regions for EFSSupportedRegionsRule in magento-master.template

### DIFF
--- a/templates/magento-master.template
+++ b/templates/magento-master.template
@@ -550,14 +550,7 @@ Rules:
     - Assert:
         !Not
         - !Contains
-          - - sa-east-1
-            - us-gov-east-1
-            - eu-north-1
-            - me-south-1
-            - ap-northeast-3
-            - ap-east-1
-            - cn-north-1
-            - cn-northwest-1
+          - - ap-northeast-3
           - !Ref AWS::Region
       AssertDescription: Amazon EFS is not currently supported in this region
 Resources:


### PR DESCRIPTION
*Issue #, if available:*
Current unable deploy magento-master.template in following regions:
- sa-east-1
- us-gov-east-1
- eu-north-1
- me-south-1
- ap-east-1
- cn-north-1
- cn-northwest-1

Stack will fail with the error ```Amazon EFS is not currently supported in this region```

*Description of changes:*
Update the rule ```EFSSupportedRegionsRule``` to match current supported EFS Regions as we have expanded this. The following Regions are now supported:
- sa-east-1
- us-gov-east-1
- eu-north-1
- me-south-1
- ap-east-1
- cn-north-1
- cn-northwest-1

You can refer to the magento.template file that already has this change 4076438 but for some reason was not reflected on the magento-master.template file.

*References*
[Amazon Elastic File System (Amazon EFS) is now available in Middle East (Bahrain), Europe (Stockholm), South America (São Paulo) and Asia Pacific (Hong Kong) regions](https://aws.amazon.com/about-aws/whats-new/2019/11/amazon-elastic-files-system-now-available-in-bahrain-stockholm-sau-paulo-hong-kong/#:~:text=Amazon%20Elastic%20File%20System%20(Amazon%20EFS)%20is%20now%20available%20in,Asia%20Pacific%20(Hong%20Kong)%20regions&text=Amazon%20Elastic%20File%20System%20(Amazon%20EFS)%20is%20now%20available%20in,AWS%20regions%20except%20China%20regions.)
[AWS Services Region Table](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/)

Regards
linjck@

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
