### PR TITLE
Fix static content generation and typo in EC2 cloudInit data

### DIFF
--- a/templates/webserver.template
+++ b/templates/webserver.template
@@ -314,8 +314,8 @@ Resources:
               content: !Sub |
                 [cfn-auto-reloader-hook]
                 triggers=post.update
-                path=Resources.LaunchConfig.Metadata.AWS::CloudFormation::Init
-                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LaunchConfig --region ${AWS::Region}
+                path=Resources.WebServerLC.Metadata.AWS::CloudFormation::Init
+                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource WebServerLC --region ${AWS::Region}
                 runas=root
             /install_magento.sh:
               source:

--- a/templates/webserver.template
+++ b/templates/webserver.template
@@ -407,6 +407,7 @@ Resources:
             /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource MagentoAMI  --region ${AWS::Region}
             chmod a+x install_magento.sh
             ./install_magento.sh /tmp/params.txt
+            php /var/www/html/bin/magento setup:static-content:deploy
             /opt/aws/bin/cfn-signal -e $? -d "`cat /home/ec2-user/adminuri`" -r "Build Process Complete" '${MagentoAMIWaitHandle}'
       Tags:
       - Key: Application


### PR DESCRIPTION
*Issue #, if available:*

Two changes made. One to address a static content issue that I ran into and I believe is the same as the issue below:
https://github.com/aws-quickstart/quickstart-magento/issues/56

The other change corrects (what I believe) is a typo in the web server EC2 cloudinit code (though its not causing an issue that I can see). 

*Description of changes:*

1. The first set of changes correct a reference to non-existent `LaunchConfig` template resource; I believe this should be referring to the `WebServerLC` resource? This change isn't causing an immediate problem that I can see, but I came across it while troubleshooting a different issue and figured I'd submit it. 

2. The second change adds `php /var/www/html/bin/magento setup:static-content:deploy` to the EC2 bootstrap actions. Without this, magento doesn't seem to deploy certain static assets (e.g. CSS) and pages don't render correctly. I think this is what's causing issue #56 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
